### PR TITLE
mac80211: increment the seqnum of PREP whenever PREQ is processed

### DIFF
--- a/net/mac80211/mesh_hwmp.c
+++ b/net/mac80211/mesh_hwmp.c
@@ -615,12 +615,10 @@ static void hwmp_preq_frame_process(struct ieee80211_sub_if_data *sdata,
 		reply = true;
 		metric = 0;
 		/* XXX right ifmsh? */
-		if (time_after(jiffies, ifmsh->last_sn_update +
-					net_traversal_jiffies(sdata)) ||
-		    time_before(jiffies, ifmsh->last_sn_update)) {
-			target_sn = ++ifmsh->sn;
-			ifmsh->last_sn_update = jiffies;
-		}
+		if (SN_LT(ifmsh->sn, target_sn))
+			ifmsh->sn = target_sn;
+		target_sn = ++ifmsh->sn;
+		ifmsh->last_sn_update = jiffies;
 	}
 
 	if (!reply && is_broadcast_ether_addr(target_addr) &&


### PR DESCRIPTION
Mesh STA A [mesh0] <----> [mesh0] Mesh STA B [mesh1] <---> [mesh0] Mesh STA C

In the case, when RANN is generated by Mesh STA A, to Mesh STA B and Mesh STA C,
PREQs are generated by both Mesh STA B and Mesh STA C respectively. Mesh STA A
will receive both PREQ from Mesh STA A and Mesh STA C almost at the same time.
In current  implementation, the sequence number is not increment due to purpose
of providing path stability in short term using dot11MeshHWMPnetDiameterTraversalTime
and this has caused Mesh STA C to resend two PREQs whenver receving RANN from Mesh
STA A. This patch is intended to increment the sequence number so that Mesh STA B
not dropping the PREP from Mesh STA A destined to Mesh STA C at first try.

Signed-off-by: Chun-Yeow Yeoh yeohchunyeow@gmail.com
