### PR TITLE
Add a debugfs file to set radio by echoing in a boolean value
``` diff
From b15e0b25ed87544bf271b5681d15c063ef069a21 Mon Sep 17 00:00:00 2001
From: Jacob Minshall <jacob@cozybit.com>
Date: Thu, 31 Oct 2013 17:03:24 -0700
Subject: [PATCH] mwl8787: add a de

### DIFF
--- a/drivers/net/wireless/mwl8787/debugfs.c
+++ b/drivers/net/wireless/mwl8787/debugfs.c
@@ -40,8 +40,26 @@ mwl8787_reset_write(struct file *file,
 	return count;
 }
 
+static ssize_t
+mwl8787_radio_set_write(struct file *file,
+			const char __user *ubuf, size_t count, loff_t *ppos)
+{
+	struct mwl8787_priv *priv =
+		(struct mwl8787_priv *) file->private_data;
+	int state;
+
+	sscanf(ubuf, "%d", &state);
+	mwl8787_cmd_radio_ctrl(priv, state);
+	return count;
+}
+
 static const struct file_operations mwl8787_reset_fops = {
 	.write = mwl8787_reset_write,
+	.open = simple_open,
+};
+
+static const struct file_operations mwl8787_radio_set_fops = {
+	.write = mwl8787_radio_set_write,
 	.open = simple_open,
 };
 
@@ -85,6 +103,7 @@ mwl8787_dev_debugfs_init(struct mwl8787_priv *priv)
 
 	MWL8787_DFS_ADD_FILE(scratch);
 	MWL8787_DFS_ADD_MODE(reset, 0200);
+	MWL8787_DFS_ADD_MODE(radio_set, 0200);
 }
 
 /*


### PR DESCRIPTION
Allow killing the radio without affecting the interface for simulated
## path healing tests.

 drivers/net/wireless/mwl8787/debugfs.c | 19 +++++++++++++++++++
 1 file changed, 19 insertions(+)

diff --git a/drivers/net/wireless/mwl8787/debugfs.c b/drivers/net/wireless/mwl8787/debugfs.c
index 2fe1478..07311f8 100644
--- a/drivers/net/wireless/mwl8787/debugfs.c
+++ b/drivers/net/wireless/mwl8787/debugfs.c
@@ -40,11 +40,29 @@ mwl8787_reset_write(struct file *file,
    return count;
 }

+static ssize_t
+mwl8787_radio_set_write(struct file *file,
-           const char __user *ubuf, size_t count, loff_t *ppos)
  +{
-   struct mwl8787_priv *priv =
-       (struct mwl8787_priv *) file->private_data;
-   int state;
  +
-   sscanf(ubuf, "%d", &state);
-   mwl8787_cmd_radio_ctrl(priv, state);
-   return count;
  +}
  +
  static const struct file_operations mwl8787_reset_fops = {
    .write = mwl8787_reset_write,
    .open = simple_open,
  };

+static const struct file_operations mwl8787_radio_set_fops = {
-   .write = mwl8787_radio_set_write,
-   .open = simple_open,
  +};
  +
  # define MWL8787_DFS_ADD_FILE(name) \
  
    debugfs_create_file(#name, 0644, priv->dfs_dev_dir,     \
            priv, &mwl8787_dfs_##name##_fops);      \
  @@ -85,6 +103,7 @@ mwl8787_dev_debugfs_init(struct mwl8787_priv *priv)
  
  MWL8787_DFS_ADD_FILE(scratch);
  MWL8787_DFS_ADD_MODE(reset, 0200);
-   MWL8787_DFS_ADD_MODE(radio_set, 0200);
  }
  ## /*
  
  1.8.1.2

```
```
